### PR TITLE
Use supermarket as berkshelf source

### DIFF
--- a/lib/knife-container/skeletons/knife_container/templates/default/berksfile.erb
+++ b/lib/knife-container/skeletons/knife_container/templates/default/berksfile.erb
@@ -1,4 +1,4 @@
-source "https://api.berkshelf.com"
+source "https://supermarket.getchef.com"
 
 <% @cookbooks.each do |cookbook| -%>
 cookbook "<%= cookbook %>"

--- a/spec/unit/fixtures/Berksfile
+++ b/spec/unit/fixtures/Berksfile
@@ -1,3 +1,3 @@
-source "https://api.berkshelf.com"
+source "https://supermarket.getchef.com"
 
 cookbook "nginx", "= 2.7.4"


### PR DESCRIPTION
The Supermarket application supports the berkshelf-api /universe endpoint used
by Berkshelf v3+. We should use that, as the api.berkshelf.com site is not
necessary.
