### PR TITLE
Add docker ENV capability

### DIFF
--- a/lib/knife-container/generator.rb
+++ b/lib/knife-container/generator.rb
@@ -43,6 +43,7 @@ module KnifeContainer
       attr_accessor :run_berks
       attr_accessor :force_build
       attr_accessor :include_credentials
+      attr_accessor :env_vars
 
     end
 
@@ -84,6 +85,7 @@ module KnifeContainer
       delegate_to_app_context :run_berks
       delegate_to_app_context :force_build
       delegate_to_app_context :include_credentials
+      delegate_to_app_context :env_vars
 
     end
 

--- a/lib/knife-container/skeletons/knife_container/templates/default/dockerfile.erb
+++ b/lib/knife-container/skeletons/knife_container/templates/default/dockerfile.erb
@@ -1,5 +1,8 @@
 # BASE <%= base_image %>
 FROM <%= dockerfile_name %>
+<% env_vars.each do |env| -%>
+ENV <%= env %>
+<% end -%>
 ADD chef/ /etc/chef/
 <% if include_credentials -%>
 RUN chef-init --bootstrap --no-remove-secure

--- a/spec/unit/container_docker_init_spec.rb
+++ b/spec/unit/container_docker_init_spec.rb
@@ -42,6 +42,8 @@ describe Chef::Knife::ContainerDockerInit do
     Chef::Config[:trusted_certs_dir] = File.join(fixtures_path, '.chef', 'trusted_certs')
     Chef::Config[:validation_client_name] = 'masterchef'
     Chef::Config[:encrypted_data_bag_secret] = File.join(fixtures_path, '.chef', 'encrypted_data_bag_secret')
+    Chef::Config[:env_vars] = ['FOO=BAR']
+    Chef::Config[:env_files] = [File.join(fixtures_path, '.chef', 'env-list')]
   end
 
   def generator_context
@@ -146,6 +148,7 @@ describe Chef::Knife::ContainerDockerInit do
         expect(config[:data_bag_path]).to eq(File.join(tempdir, 'data_bags'))
         expect(config[:dockerfiles_path]).to eq(File.join(tempdir, 'dockerfiles'))
         expect(config[:run_list]).to eq([])
+        expect(config[:env_vars]).to eq(['FOO=BAR', 'SOMETHING=nothing'])
       end
 
       context 'when cookbook_path is an array' do

--- a/spec/unit/fixtures/.chef/env-list
+++ b/spec/unit/fixtures/.chef/env-list
@@ -1,0 +1,1 @@
+SOMETHING=nothing


### PR DESCRIPTION
Reasons:
 - Docker doesn't care about environments variables even if we use system
 files such as /etc/environment or /etc/profile. Otherwise we must use
 --env-files or --env when running docker with command line.

Changes:
 - Add --env (multiple call possible) and --env-files PATH[:PATH] in
 docker init
 - This will add some lines in Dockerfile
```
Example:
    --env FOO=BAR --env BAZ=BAT
    # Will add
    ENV FOO=BAR
    ENV BAZ=BAT
```